### PR TITLE
Updated how multi-word keywords are supposed to be implemented

### DIFF
--- a/theDefault/src/main/java/defaultmod/DefaultMod.java
+++ b/theDefault/src/main/java/defaultmod/DefaultMod.java
@@ -301,13 +301,19 @@ public class DefaultMod implements
 
     @Override
     public void receiveEditKeywords() {
+        // keywords on cards are supposed to be Capitalized, while in Keyword-String.json they're lowercase
+
+        // multiword keywords are done with_underscores
+        // if you're using multiword keyword, the first element in your NAMES array in your keywords-strings.json has to be the same as the PROPER_NAME
+        // that is, in Card-Strings.json you would have a_long_keyword
+        // and in Keyword-Strings.json you would have PROPER_NAME as A Long Keyword, and the first element in NAMES be A Long Keyword, and the second element be a_long_keyword
         Gson gson = new Gson();
         String json = Gdx.files.internal("defaultModResources/localization/eng/DefaultMod-Keyword-Strings.json").readString(String.valueOf(StandardCharsets.UTF_8));
         com.evacipated.cardcrawl.mod.stslib.Keyword[] keywords = gson.fromJson(json, com.evacipated.cardcrawl.mod.stslib.Keyword[].class);
 
         if (keywords != null) {
             for (Keyword keyword : keywords) {
-                BaseMod.addKeyword(keyword.NAMES, keyword.DESCRIPTION);
+                BaseMod.addKeyword(keyword.PROPER_NAME, keyword.NAMES, keyword.DESCRIPTION);
             }
         }
     }

--- a/theDefault/src/main/resources/defaultModResources/localization/eng/DefaultMod-Keyword-Strings.json
+++ b/theDefault/src/main/resources/defaultModResources/localization/eng/DefaultMod-Keyword-Strings.json
@@ -1,6 +1,5 @@
 [
   {
-    "PROPER_NAME": "Placeholder",
     "NAMES": [
       "keyword",
       "keywords",
@@ -9,7 +8,16 @@
       "Keyword:"
     ],
     "DESCRIPTION": "Whenever you play a card, gain 1 dexterity this turn only."
+  },
+  {
+    "PROPER_NAME": "Multiword Keyword",
+    "NAMES": [
+      "Multiword Keyword",
+      "multiword_keyword",
+      "multiword_keywords",
+      "multikey",
+      "multikeyword"
+    ],
+    "DESCRIPTION": "Make sure the first element in the NAMES is the same as your PROPER_NAME. The rest is to match keywords like the single word keyword."
   }
 ]
-
-


### PR DESCRIPTION
The previous implementation doesn't actually work for multi-word keywords, since the code part wasn't modified to add PROPER_NAME in.

Also, the first element in NAMES has to be the same as PROPER_NAME (spaces and all) is because in the BaseMod code, it sets the word to be displayed on the card to the NAMES[0]. This means that although it feels redundant to have to have 2 elements in NAMES at least (one with spaces and one with underscores) it's necessary to have it display properly on cards.

Hopefully I haven't broken anything.