### PR TITLE
Fix pom.xml warning

### DIFF
--- a/theDefault/pom.xml
+++ b/theDefault/pom.xml
@@ -67,7 +67,7 @@
                         <configuration>
                             <target>
                                 <!-- Change to match your mods name. This moves your mod into a common folder where all mods you make can go. -->
-                                <copy file="target/DefaultMod.jar" tofile="${Steam.path}/common/SlayTheSpire/mods/${artifactId}.jar"/>
+                                <copy file="target/DefaultMod.jar" tofile="${Steam.path}/common/SlayTheSpire/mods/${project.artifactId}.jar"/>
                                 <!--<copy file="target/DefaultMod.jar" tofile="../mods/DefaultMod.jar"/>-->
                             </target>
                         </configuration>


### PR DESCRIPTION
Maven was showing this warning:

[WARNING] Some problems were encountered while building the effective model for cardchanneler:CardChanneler:jar:1.0.0
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.