### PR TITLE
Run mods through Steam instead of MTS.cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can also asign a shortcut to the both those commands by opening the Lifecycl
 
 You can now find your mod in `[slay the spire install folder]/mods/[name_of_mod].jar`. If you  can't find it, check at the bottom of your pom.xml for the location.
 
-You should be able to run Slay the Spire by running `MTS.cmd` (`MTS.sh` on a mac).
+You should be able to run Slay the Spire through Steam by selecting `Play With Mods`.
 BUT WAIT
 If you wanna run it with IntelliJ and get cool clickable line numbers when you get a crash-log that'll instantly direct you to where your error is:
 


### PR DESCRIPTION
Updated docs for running mods through Steam instead of `MTS.cmd` (which is now deprecated)

Resolves #44 