### PR TITLE
Fix shoulder images order

### DIFF
--- a/theDefault/src/main/java/theDefault/characters/TheDefault.java
+++ b/theDefault/src/main/java/theDefault/characters/TheDefault.java
@@ -110,8 +110,8 @@ public class TheDefault extends CustomPlayer {
 
         initializeClass(null, // required call to load textures and setup energy/loadout.
                 // I left these in DefaultMod.java (Ctrl+click them to see where they are, Ctrl+hover to see what they read.)
-                THE_DEFAULT_SHOULDER_1, // campfire pose
-                THE_DEFAULT_SHOULDER_2, // another campfire pose
+                THE_DEFAULT_SHOULDER_2, // campfire pose
+                THE_DEFAULT_SHOULDER_1, // another campfire pose
                 THE_DEFAULT_CORPSE, // dead corpse
                 getLoadout(), 20.0F, -10.0F, 220.0F, 290.0F, new EnergyManager(ENERGY_PER_TURN)); // energy manager
 


### PR DESCRIPTION
Fix the order of the parameters of initializeClass in our call to not mix up the images.
The method signature begins with: initializeClass(String imgUrl, String shoulder2ImgUrl, String shouldImgUrl, [...]