### PR TITLE
Updated initial setup comments to account for autoAdd and keywords

### DIFF
--- a/theDefault/src/main/java/theDefault/DefaultMod.java
+++ b/theDefault/src/main/java/theDefault/DefaultMod.java
@@ -42,13 +42,14 @@ import java.util.Properties;
 //TODO: DON'T MASS RENAME/REFACTOR
 //TODO: DON'T MASS RENAME/REFACTOR
 // Please don't just mass replace "theDefault" with "yourMod" everywhere.
-// It'll be a bigger pain for you. You only need to replace it in 3 places.
+// It'll be a bigger pain for you. You only need to replace it in 4 places.
 // I comment those places below, under the place where you set your ID.
 
 //TODO: FIRST THINGS FIRST: RENAME YOUR PACKAGE AND ID NAMES FIRST-THING!!!
 // Right click the package (Open the project pane on the left. Folder with black dot on it. The name's at the very top) -> Refactor -> Rename, and name it whatever you wanna call your mod.
 // Scroll down in this file. Change the ID from "theDefault:" to "yourModName:" or whatever your heart desires (don't use spaces). Dw, you'll see it.
-// In the JSON strings (resources>localization>eng>[all them files] make sure they all go "yourModName:" rather than "theDefault". You can ctrl+R to replace in 1 file, or ctrl+shift+r to mass replace in specific files/directories (Be careful.).
+// In the JSON strings (resources>localization>eng>[all them files] make sure they all go "yourModName:" rather than "theDefault", and change to "yourmodname" rather than "thedefault".
+// You can ctrl+R to replace in 1 file, or ctrl+shift+r to mass replace in specific files/directories, and press alt+c to make the replace case sensetive (Be careful.).
 // Start with the DefaultCommon cards - they are the most commented cards since I don't feel it's necessary to put identical comments on every card.
 // After you sorta get the hang of how to make cards, check out the card template which will make your life easier
 
@@ -188,11 +189,15 @@ public class DefaultMod implements
         // 1. Go to your resources folder in the project panel, and refactor> rename theDefaultResources to
         // yourModIDResources.
         
-        // 2. Click on the localization > eng folder and press ctrl+shift+r, then select "Directory" (rather than in Project)
-        // replace all instances of theDefault with yourModID.
+        // 2. Click on the localization > eng folder and press ctrl+shift+r, then select "Directory" (rather than in Project) and press alt+c (or mark the match case option)
+        // replace all instances of theDefault with yourModID, and all instances of thedefault with yourmodid (the same but all lowcase).
         // Because your mod ID isn't the default. Your cards (and everything else) should have Your mod id. Not mine.
-        
-        // 3. FINALLY and most importantly: Scroll up a bit. You may have noticed the image locations above don't use getModID()
+        // It's important that the mod ID prefix for keywords used in the cards descriptions is lowercase!
+
+        // 3. Scroll down (or search for "ADD CARDS") till you reach the ADD CARDS section, and follow the TODO instructions
+        // You'll need to change both the mod Id you changed here and the one in ModTheSpire.json in the autoAdd function
+
+        // 4. FINALLY and most importantly: Scroll up a bit. You may have noticed the image locations above don't use getModID()
         // Change their locations to reflect your actual ID rather than theDefault. They get loaded before getID is a thing.
         
         logger.info("Done subscribing");
@@ -414,6 +419,10 @@ public class DefaultMod implements
         // The ID for this function isn't actually your modid as used for prefixes/by the getModID() method.
         // It's the mod id you give MTS in ModTheSpire.json - by default your artifact ID in your pom.xml
 
+        //TODO: Rename the "YourNameHere:DefaultMod" with the modid in your ModTheSpire.json file
+        //TODO: The artifact mentioned in ModTheSpire.json is the artifactId in pom.xml you should've edited earlier
+        //TODO: Then change the "theDefault.cards" into "yourPackageName.cards" (with the actual package name instead)
+        //TODO: Your package name should be the same as the mod id if you followed the instructions at the top of the file
         new AutoAdd("YourNameHere:DefaultMod")
             .packageFilter("theDefault.cards")
             .setDefaultSeen(true)
@@ -470,7 +479,7 @@ public class DefaultMod implements
     // ================ /LOAD THE TEXT/ ===================
     
     // ================ LOAD THE KEYWORDS ===================
-    
+
     @Override
     public void receiveEditKeywords() {
         // Keywords on cards are supposed to be Capitalized, while in Keyword-String.json they're lowercase


### PR DESCRIPTION
So after wasting probably half a day debugging why my default mod wouldn't work after following all the notes to the T,
I managed to find yet another place where the Mod Id needs to be updated that wasn't documented and was skipped by IDE during Refactor-Rename.
I added another change step near the Mod ID init to mention the change and more detailed note just by the AutoAdd function for the cards that explains exactly what and how needs to change.

Also while at it I updated the notes about Localization to take into account capitalization (or rather important lack of) for mod ID where Keywords are concerned, since I also wasted about a hour and a half trying to understand why the Keywords didn't display properly in game.